### PR TITLE
Support installing on OTP27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
 
     strategy:
       matrix:
-        otp-version: [24, 25, 26]
-        os: [ubuntu-24.04]
+        otp-version: [24, 25, 26, 27]
+        os: [ubuntu-24.04, windows-latest]
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,0 +1,15 @@
+OtpVersion = list_to_integer(erlang:system_info(otp_release)),
+
+Hooks = case lists:keyfind(post_hooks, 1, CONFIG) of
+    false -> [];
+    {post_hooks, V} -> V
+end,
+
+NewHooks = case OtpVersion >= 27 of
+    true ->
+        [{erlc_compile, "rm \"$REBAR_DEPS_DIR/json_polyfill/ebin/json.beam\""}];
+    false ->
+        []
+end,
+
+lists:keystore(erl_opts, 1, CONFIG, {post_hooks, Hooks ++ NewHooks}).


### PR DESCRIPTION
Deletes the `json.beam` output file when running on a newer OTP version. This makes it feasible to unconditionally include this dependency.